### PR TITLE
test: cover core and application flows

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  env: {
+    es2021: true,
+    node: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.base.json'],
+    tsconfigRootDir: __dirname,
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['node_modules/', 'dist/', '*.config.js', '*.config.cjs', '*.config.ts', 'archive/', 'assets/', 'js/', 'styles/', 'scripts/', 'data.js', 'index.html', 'bands-scraper/'],
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      excludedFiles: ['js/**']
+    }
+  ]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ scripts/.env
 # Mac files
 .DS_Store
 */.DS_Store
+
+# Build output
+dist/
+**/dist/
+*.tsbuildinfo
+**/*.tsbuildinfo

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,10 @@
+# @asheville-music-chart/web
+
+This package will host the refactored web presentation layer. During the transition it can
+coexist with the legacy static assets at the repository root.
+
+## Scripts
+
+- `npm run build` – compiles the TypeScript sources.
+- `npm run lint` – runs the shared ESLint configuration against local files.
+- `npm run test` – executes the workspace Vitest suite.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@asheville-music-chart/web",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Web presentation app for the Asheville Music Chart",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "node -e \"console.log('No web tests defined yet')\""
+  }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,0 +1,3 @@
+// Placeholder entry point for the future web application.
+// The refactor will gradually migrate the legacy browser codebase into this workspace.
+export const placeholder = true;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/docs/current-behavior.md
+++ b/docs/current-behavior.md
@@ -1,0 +1,46 @@
+# Current Front-End and Data Pipeline Behavior
+
+## Browser Boot Sequence
+- `index.html` bootstraps the page by loading the static header/menu scripts and the ES module entry point that wires up chart rendering once `DOMContentLoaded` fires.【F:index.html†L30-L55】
+- On load, the page renders the support/recommend/feedback menu via `renderMainMenu` and the logo/header via `renderMainHeader` before attempting to load chart data.【F:index.html†L39-L47】【F:js/mainMenu.js†L5-L46】【F:js/mainHeader.js†L5-L21】
+- The module fetches chart data through `loadChartData()`, normalizes the payload to an array, and delegates to `renderChart` with optional week-range display hints.【F:index.html†L42-L49】
+
+## Data Contracts and Loading Rules
+- Each chart dataset is a JSON object with a `timestamp` and `data` array; every artist entry contains an `artist` metadata object and a `weeks` collection with Spotify listen totals and optional week-over-week deltas.【F:archive/data_2025-06-13T12-47-06-325Z.js†L1-L47】
+- The root `data.js` file mirrors this structure and may be empty when no chart has been published yet.【F:data.js†L1-L4】
+- `loadChartData()` first returns the root dataset when it has non-empty `data`, otherwise it lazily iterates over the generated archive manifest and dynamically imports the first dataset that includes rows, deriving the display week start/end dates from the selected timestamp.【F:js/dataLoader.js†L4-L54】【F:archive/manifest.js†L1-L23】
+
+## Chart Rendering Responsibilities
+- `renderChart` owns the sticky header tabs (`Top`, `Hottest`, `Shows`), the tab-specific description block, the inline alert mount point, and the cell container wrapper appended beneath the sticky header region.【F:js/chart.js†L9-L47】
+- The function computes a fallback display range by examining the most recent artist week when the loader does not supply `displayWeekStart`/`displayWeekEnd`, and formats the range using shared date helpers.【F:js/chart.js†L52-L77】
+- Tab descriptions depend on whether data exists, with the info icon toggling the inline alert when present; without data, both the `Top` and `Hottest` descriptions show a missing-data message while `Shows` always renders a stub copy for the current month.【F:js/chart.js†L79-L117】
+- Artist records are copied, sorted by latest-week listens, and wrapped with an `index` and a `getChangeIndicator` helper that produces up/down HTML based on the two most recent weeks.【F:js/chart.js†L127-L152】
+- The `renderEmptyState` helper swaps the cells container contents with a message when the filter result is empty or data is unavailable.【F:js/chart.js†L119-L125】
+
+## Filtering & Alert Interaction Contracts
+- A `FilterController` instance coordinates a `FilterService`, floating `FilterButton`, and dynamically created `FilterMenu`. Initialization registers the source dataset, renders the mobile-only filter button, and immediately pushes the unfiltered results back to the chart renderer.【F:js/chart.js†L155-L175】【F:js/filterController.js†L7-L36】
+- Selecting a genre applies the filter inside `FilterService`, updates button state (text + active class), and re-renders the artist cells; clearing filters resets to the full list.【F:js/filterController.js†L89-L112】【F:js/filterService.js†L13-L68】【F:js/filterButton.js†L5-L40】
+- The controller listens for window resize to remove the floating button and close the overlay on desktop widths, and to recreate it when shrinking back to mobile.【F:js/filterController.js†L114-L129】 The menu overlay renders as a dialog, wires click handlers for option selection/close, and attaches `Escape` handling for dismissal.【F:js/filterMenu.js†L14-L86】
+- `InlineAlert` renders descriptive copy with an expandable “How it works” section, tracks its own visibility, and exposes `show`/`hide`/`destroy` while clearing the info-icon active state when dismissed.【F:js/inlineAlert.js†L5-L112】 `renderChart` auto-opens the alert shortly after mount and toggles it whenever the info icon is activated.【F:js/chart.js†L177-L201】
+
+## Artist Cell Rendering & Mobile Behaviors
+- `renderArtistCells` determines the highest week-over-week improvement rate, instantiates an `ArtistCell` per artist, and adds a fire emoji plus `highest-improver` class to the leader.【F:js/artistCells.js†L1-L58】
+- Each cell prints the ordinal rank, artist metadata, Spotify link, formatted listen total, and change indicator (with `NEW!` badge for one-week histories).【F:js/artistCells.js†L39-L100】
+- A mobile-only `setupJumpingSpotifyOnScroll` hook highlights the Spotify button for the card closest to one-third viewport height, fading out previous highlights, and is exposed globally for `renderChart` to call after rendering.【F:js/artistCells.js†L103-L151】【F:js/chart.js†L269-L273】
+
+## Tab Switching & Lifecycle Hooks
+- Switching tabs adjusts the active class, injects the appropriate description markup, and either renders sorted artists for `Top`/`Hottest` or shows a placeholder banner for the upcoming `Shows` tab while hiding the inline alert.【F:js/chart.js†L230-L260】
+- The chart registers global resize and `beforeunload` listeners to refresh filter UI state and to clean up filter/alert instances when navigating away.【F:js/chart.js†L263-L282】
+
+## Legacy Script Entry Point
+- The historical `script.js` still ships a `DOMContentLoaded` handler that sorts the global `data.data` array, instantiates a DOM-only `ArtistChart`, and renders basic cells without tabs, filters, or alerts. The class assumes each artist object has a `weeks` array with at least one entry and uses the last two weeks to build the change indicator.【F:script.js†L1-L70】
+
+## Ancillary UI Modules
+- `renderMainMenu` inserts three CTA links (Support Asheville, Recommend Artist, Give Feedback) into the sticky header, while `renderMainHeader` outputs the logo and subtitle hero block; both expose themselves via `window` for the entry module to call.【F:js/mainMenu.js†L5-L46】【F:js/mainHeader.js†L5-L21】
+- Date formatting helpers provide presentation-friendly strings for the chart header, showing the start date with a month/day suffix and the end date condensed unless the week spans multiple months.【F:js/dateFormatting.js†L1-L25】
+
+## Data Update Pipeline (Soundcharts)
+- `scripts/updateData.js` loads environment variables for the Soundcharts API credentials, reads `scripts/artists.json`, and builds two contiguous 7-day ranges covering weeks -16 to -9 and -8 to -1 relative to execution.【F:scripts/updateData.js†L8-L56】
+- For each artist, it requests Spotify listening data over the combined range, validates the response structure, and reduces the daily points into totals for each tracked week while calculating week-over-week change metadata.【F:scripts/updateData.js†L87-L171】
+- After processing all artists, the script timestamps the aggregate payload, archives the previous `data.js` snapshot with an ISO-stamped filename, writes the new dataset, and regenerates `archive/manifest.js` by listing archive files in reverse chronological order.【F:scripts/updateData.js†L173-L218】
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "asheville-music-chart",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "asheville-music-chart",
+      "version": "1.0.0",
+      "workspaces": [
+        "apps/*",
+        "packages/*",
+        "tools/*"
+      ],
+      "devDependencies": {}
+    },
+    "apps/web": {
+      "name": "@asheville-music-chart/web",
+      "version": "0.0.0"
+    },
+    "node_modules/@asheville-music-chart/application": {
+      "resolved": "packages/application",
+      "link": true
+    },
+    "node_modules/@asheville-music-chart/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@asheville-music-chart/data-pipeline": {
+      "resolved": "tools/data-pipeline",
+      "link": true
+    },
+    "node_modules/@asheville-music-chart/infrastructure": {
+      "resolved": "packages/infrastructure",
+      "link": true
+    },
+    "node_modules/@asheville-music-chart/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
+    "packages/application": {
+      "name": "@asheville-music-chart/application",
+      "version": "0.0.0"
+    },
+    "packages/core": {
+      "name": "@asheville-music-chart/core",
+      "version": "0.0.0"
+    },
+    "packages/infrastructure": {
+      "name": "@asheville-music-chart/infrastructure",
+      "version": "0.0.0"
+    },
+    "tools/data-pipeline": {
+      "name": "@asheville-music-chart/data-pipeline",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,19 @@
 {
   "name": "asheville-music-chart",
+  "private": true,
   "version": "1.0.0",
-  "description": "Asheville Music Chart data updater",
-  "main": "scripts/updateData.js",
+  "description": "Asheville Music Chart monorepo",
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "tools/*"
+  ],
   "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
     "update": "node scripts/updateData.js"
   },
-  "dependencies": {
-    "node-fetch": "^2.6.7",
-    "dotenv": "^16.0.3",
-    "date-fns": "^2.29.3"
-  }
-} 
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/application/README.md
+++ b/packages/application/README.md
@@ -1,0 +1,25 @@
+# @asheville-music-chart/application
+
+This package coordinates application-level workflows for the Asheville Music Chart refactor. It
+wraps the core domain models with use cases, DTOs, and boundary interfaces so presentation layers
+and tooling can interact with the chart without touching persistence or external services
+directly.
+
+## Available surface area
+
+### Ports
+- `ChartReadRepository` / `ChartWriteRepository` describe how to load and persist the current chart
+  snapshot.
+- `ArchiveRepository` surfaces historical chart storage with discovery APIs.
+- `EventRepository` provides upcoming show listings keyed by artist.
+- `ArtistImageService` looks up display-ready imagery for artists missing artwork.
+
+### Use cases
+- `GetCurrentChartUseCase` returns the latest chart as serializable DTOs.
+- `FilterArtistsUseCase` applies domain filtering policies before presenting data to the UI.
+- `ListGrowthLeadersUseCase` exposes a ranked leaderboard driven by week-over-week momentum.
+- `UpdateChartDataUseCase` orchestrates ingestion pipelines, image enrichment, and archive writes.
+
+### DTOs and mappers
+DTO helpers convert domain entities (`Chart`, `ArtistHistory`, `WeeklyStat`) into immutable data
+contracts suitable for transport across the application boundary.

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@asheville-music-chart/application",
+  "version": "0.0.0",
+  "description": "Application services and use cases for the Asheville Music Chart",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "npm run build && node --loader ../../test-support/esm-loader.mjs --test ./tests/*.test.js"
+  }
+}

--- a/packages/application/src/dtos/artist-history.ts
+++ b/packages/application/src/dtos/artist-history.ts
@@ -1,0 +1,11 @@
+import type { ArtistDTO } from './artist';
+import type { GrowthSnapshotDTO } from './growth';
+import type { WeeklyStatDTO } from './weekly-stat';
+
+export interface ArtistHistoryDTO {
+  readonly artist: ArtistDTO;
+  readonly weeks: readonly WeeklyStatDTO[];
+  readonly currentWeek: WeeklyStatDTO;
+  readonly previousWeek?: WeeklyStatDTO;
+  readonly growth: GrowthSnapshotDTO;
+}

--- a/packages/application/src/dtos/artist.ts
+++ b/packages/application/src/dtos/artist.ts
@@ -1,0 +1,8 @@
+export interface ArtistDTO {
+  readonly id: string;
+  readonly name: string;
+  readonly imageUrl?: string;
+  readonly highLevelGenre?: string;
+  readonly specificGenre?: string;
+  readonly spotifyUrl?: string;
+}

--- a/packages/application/src/dtos/chart.ts
+++ b/packages/application/src/dtos/chart.ts
@@ -1,0 +1,6 @@
+import type { ArtistHistoryDTO } from './artist-history';
+
+export interface ChartDTO {
+  readonly generatedAt: string;
+  readonly entries: readonly ArtistHistoryDTO[];
+}

--- a/packages/application/src/dtos/event.ts
+++ b/packages/application/src/dtos/event.ts
@@ -1,0 +1,12 @@
+export interface ArtistEventDTO {
+  readonly id?: string;
+  readonly artistId: string;
+  readonly name: string;
+  readonly startDate: string;
+  readonly endDate?: string;
+  readonly venue?: string;
+  readonly city?: string;
+  readonly country?: string;
+  readonly url?: string;
+  readonly source?: string;
+}

--- a/packages/application/src/dtos/growth.ts
+++ b/packages/application/src/dtos/growth.ts
@@ -1,0 +1,8 @@
+import type { WeeklyStatDTO } from './weekly-stat';
+
+export interface GrowthSnapshotDTO {
+  readonly current: WeeklyStatDTO;
+  readonly previous?: WeeklyStatDTO;
+  readonly absoluteChange: number | null;
+  readonly percentageChange: number | null;
+}

--- a/packages/application/src/dtos/index.ts
+++ b/packages/application/src/dtos/index.ts
@@ -1,0 +1,7 @@
+export type { ArtistDTO } from './artist';
+export type { WeeklyStatDTO } from './weekly-stat';
+export type { GrowthSnapshotDTO } from './growth';
+export type { ArtistHistoryDTO } from './artist-history';
+export type { ChartDTO } from './chart';
+export type { RankedArtistDTO, GrowthLeaderboardEntryDTO } from './leaderboard';
+export type { ArtistEventDTO } from './event';

--- a/packages/application/src/dtos/leaderboard.ts
+++ b/packages/application/src/dtos/leaderboard.ts
@@ -1,0 +1,14 @@
+import type { ArtistHistoryDTO } from './artist-history';
+import type { GrowthSnapshotDTO } from './growth';
+
+export interface RankedArtistDTO {
+  readonly rank: number;
+  readonly score: number;
+  readonly history: ArtistHistoryDTO;
+}
+
+export interface GrowthLeaderboardEntryDTO {
+  readonly rank: number;
+  readonly history: ArtistHistoryDTO;
+  readonly growth: GrowthSnapshotDTO;
+}

--- a/packages/application/src/dtos/weekly-stat.ts
+++ b/packages/application/src/dtos/weekly-stat.ts
@@ -1,0 +1,6 @@
+export interface WeeklyStatDTO {
+  readonly weekStartDate: string;
+  readonly weekEndDate: string;
+  readonly totalListens: number;
+  readonly listensDifference?: number;
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,0 +1,4 @@
+export * from './dtos';
+export * from './ports';
+export * from './use-cases';
+export * from './mappers';

--- a/packages/application/src/mappers/artist-history.ts
+++ b/packages/application/src/mappers/artist-history.ts
@@ -1,0 +1,52 @@
+import { currentGrowth, type GrowthSnapshot, type ArtistHistory, type Artist, type WeeklyStat } from '@asheville-music-chart/core';
+
+import type {
+  ArtistDTO,
+  ArtistHistoryDTO,
+  GrowthSnapshotDTO,
+  WeeklyStatDTO,
+} from '../dtos';
+
+function toArtistDTO(artist: Artist): ArtistDTO {
+  return {
+    id: artist.id,
+    name: artist.name,
+    imageUrl: artist.imageUrl,
+    highLevelGenre: artist.highLevelGenre,
+    specificGenre: artist.specificGenre,
+    spotifyUrl: artist.spotifyUrl,
+  };
+}
+
+function toWeeklyStatDTO(stat: WeeklyStat): WeeklyStatDTO {
+  return {
+    weekStartDate: stat.period.start,
+    weekEndDate: stat.period.end,
+    totalListens: stat.totalListens.value,
+    listensDifference: stat.listensDifference,
+  };
+}
+
+function toGrowthSnapshotDTO(snapshot: GrowthSnapshot): GrowthSnapshotDTO {
+  return {
+    current: toWeeklyStatDTO(snapshot.current),
+    previous: snapshot.previous ? toWeeklyStatDTO(snapshot.previous) : undefined,
+    absoluteChange: snapshot.absoluteChange,
+    percentageChange: snapshot.percentageChange,
+  };
+}
+
+export function toArtistHistoryDTO(history: ArtistHistory): ArtistHistoryDTO {
+  const growth = currentGrowth(history);
+  const weeks = history.weeks.map((week) => toWeeklyStatDTO(week));
+
+  return {
+    artist: toArtistDTO(history.artist),
+    weeks,
+    currentWeek: toWeeklyStatDTO(history.currentWeek),
+    previousWeek: history.previousWeek ? toWeeklyStatDTO(history.previousWeek) : undefined,
+    growth: toGrowthSnapshotDTO(growth),
+  };
+}
+
+export { toArtistDTO, toWeeklyStatDTO, toGrowthSnapshotDTO };

--- a/packages/application/src/mappers/chart.ts
+++ b/packages/application/src/mappers/chart.ts
@@ -1,0 +1,11 @@
+import type { Chart } from '@asheville-music-chart/core';
+
+import type { ChartDTO } from '../dtos';
+import { toArtistHistoryDTO } from './artist-history';
+
+export function toChartDTO(chart: Chart): ChartDTO {
+  return {
+    generatedAt: chart.generatedAt.toISOString(),
+    entries: chart.entries.map((entry) => toArtistHistoryDTO(entry)),
+  };
+}

--- a/packages/application/src/mappers/index.ts
+++ b/packages/application/src/mappers/index.ts
@@ -1,0 +1,3 @@
+export { toArtistDTO, toWeeklyStatDTO, toGrowthSnapshotDTO, toArtistHistoryDTO } from './artist-history';
+export { toRankedArtistDTO } from './ranking';
+export { toChartDTO } from './chart';

--- a/packages/application/src/mappers/ranking.ts
+++ b/packages/application/src/mappers/ranking.ts
@@ -1,0 +1,12 @@
+import type { RankedArtist } from '@asheville-music-chart/core';
+
+import type { RankedArtistDTO } from '../dtos';
+import { toArtistHistoryDTO } from './artist-history';
+
+export function toRankedArtistDTO(entry: RankedArtist): RankedArtistDTO {
+  return {
+    rank: entry.rank,
+    score: entry.score,
+    history: toArtistHistoryDTO(entry.history),
+  };
+}

--- a/packages/application/src/ports/archive-repository.ts
+++ b/packages/application/src/ports/archive-repository.ts
@@ -1,0 +1,13 @@
+import type { Chart } from '@asheville-music-chart/core';
+
+export interface ArchivedChartSummary {
+  readonly generatedAt: Date;
+  readonly artistCount: number;
+  readonly source?: string;
+}
+
+export interface ArchiveRepository {
+  listSnapshots(): Promise<readonly ArchivedChartSummary[]>;
+  loadSnapshot(generatedAt: Date): Promise<Chart | null>;
+  saveSnapshot(chart: Chart): Promise<void>;
+}

--- a/packages/application/src/ports/artist-image-service.ts
+++ b/packages/application/src/ports/artist-image-service.ts
@@ -1,0 +1,5 @@
+import type { Artist } from '@asheville-music-chart/core';
+
+export interface ArtistImageService {
+  findImageFor(artist: Artist): Promise<string | null>;
+}

--- a/packages/application/src/ports/chart-repository.ts
+++ b/packages/application/src/ports/chart-repository.ts
@@ -1,0 +1,11 @@
+import type { Chart } from '@asheville-music-chart/core';
+
+export interface ChartReadRepository {
+  loadLatest(): Promise<Chart>;
+}
+
+export interface ChartWriteRepository {
+  save(chart: Chart): Promise<void>;
+}
+
+export type ChartRepository = ChartReadRepository & ChartWriteRepository;

--- a/packages/application/src/ports/event-repository.ts
+++ b/packages/application/src/ports/event-repository.ts
@@ -1,0 +1,11 @@
+import type { ArtistEventDTO } from '../dtos';
+
+export interface UpcomingEventsQuery {
+  readonly limit?: number;
+  readonly startDate?: Date;
+  readonly endDate?: Date;
+}
+
+export interface EventRepository {
+  listUpcomingEvents(artistId: string, query?: UpcomingEventsQuery): Promise<readonly ArtistEventDTO[]>;
+}

--- a/packages/application/src/ports/index.ts
+++ b/packages/application/src/ports/index.ts
@@ -1,0 +1,4 @@
+export type { ChartReadRepository, ChartWriteRepository, ChartRepository } from './chart-repository';
+export type { ArchiveRepository, ArchivedChartSummary } from './archive-repository';
+export type { EventRepository, UpcomingEventsQuery } from './event-repository';
+export type { ArtistImageService } from './artist-image-service';

--- a/packages/application/src/use-cases/filter-artists.ts
+++ b/packages/application/src/use-cases/filter-artists.ts
@@ -1,0 +1,30 @@
+import { filterArtists, type FilterCriteria } from '@asheville-music-chart/core';
+
+import type { ArtistHistoryDTO } from '../dtos';
+import { toArtistHistoryDTO } from '../mappers';
+import type { ChartReadRepository } from '../ports';
+
+export interface FilterArtistsRequest {
+  readonly criteria?: FilterCriteria;
+}
+
+export interface FilterArtistsResponse {
+  readonly entries: readonly ArtistHistoryDTO[];
+  readonly totalMatched: number;
+  readonly totalAvailable: number;
+}
+
+export class FilterArtistsUseCase {
+  constructor(private readonly charts: ChartReadRepository) {}
+
+  async execute({ criteria }: FilterArtistsRequest = {}): Promise<FilterArtistsResponse> {
+    const chart = await this.charts.loadLatest();
+    const filtered = filterArtists(chart.entries, criteria);
+
+    return {
+      entries: filtered.map((history) => toArtistHistoryDTO(history)),
+      totalMatched: filtered.length,
+      totalAvailable: chart.size,
+    } satisfies FilterArtistsResponse;
+  }
+}

--- a/packages/application/src/use-cases/get-current-chart.ts
+++ b/packages/application/src/use-cases/get-current-chart.ts
@@ -1,0 +1,21 @@
+import type { ChartReadRepository } from '../ports';
+import type { ChartDTO } from '../dtos';
+import { toChartDTO } from '../mappers';
+
+export interface GetCurrentChartResponse {
+  readonly chart: ChartDTO;
+  readonly artistCount: number;
+}
+
+export class GetCurrentChartUseCase {
+  constructor(private readonly charts: ChartReadRepository) {}
+
+  async execute(): Promise<GetCurrentChartResponse> {
+    const chart = await this.charts.loadLatest();
+
+    return {
+      chart: toChartDTO(chart),
+      artistCount: chart.size,
+    } satisfies GetCurrentChartResponse;
+  }
+}

--- a/packages/application/src/use-cases/index.ts
+++ b/packages/application/src/use-cases/index.ts
@@ -1,0 +1,16 @@
+export { GetCurrentChartUseCase, type GetCurrentChartResponse } from './get-current-chart';
+export {
+  FilterArtistsUseCase,
+  type FilterArtistsRequest,
+  type FilterArtistsResponse,
+} from './filter-artists';
+export {
+  ListGrowthLeadersUseCase,
+  type ListGrowthLeadersRequest,
+  type ListGrowthLeadersResponse,
+} from './list-growth-leaders';
+export {
+  UpdateChartDataUseCase,
+  type UpdateChartDataRequest,
+  type UpdateChartDataResponse,
+} from './update-chart-data';

--- a/packages/application/src/use-cases/list-growth-leaders.ts
+++ b/packages/application/src/use-cases/list-growth-leaders.ts
@@ -1,0 +1,34 @@
+import { applyRanking, currentGrowth, weekOverWeekGrowthRule } from '@asheville-music-chart/core';
+
+import type { GrowthLeaderboardEntryDTO } from '../dtos';
+import { toArtistHistoryDTO, toGrowthSnapshotDTO } from '../mappers';
+import type { ChartReadRepository } from '../ports';
+
+export interface ListGrowthLeadersRequest {
+  readonly limit?: number;
+}
+
+export interface ListGrowthLeadersResponse {
+  readonly leaders: readonly GrowthLeaderboardEntryDTO[];
+}
+
+export class ListGrowthLeadersUseCase {
+  constructor(private readonly charts: ChartReadRepository) {}
+
+  async execute({ limit }: ListGrowthLeadersRequest = {}): Promise<ListGrowthLeadersResponse> {
+    const chart = await this.charts.loadLatest();
+    const ranked = applyRanking(chart, weekOverWeekGrowthRule).filter((entry) => Number.isFinite(entry.score));
+
+    const leaders = (typeof limit === 'number' && limit >= 0)
+      ? ranked.slice(0, limit)
+      : ranked;
+
+    return {
+      leaders: leaders.map((entry) => ({
+        rank: entry.rank,
+        history: toArtistHistoryDTO(entry.history),
+        growth: toGrowthSnapshotDTO(currentGrowth(entry.history)),
+      })),
+    } satisfies ListGrowthLeadersResponse;
+  }
+}

--- a/packages/application/src/use-cases/update-chart-data.ts
+++ b/packages/application/src/use-cases/update-chart-data.ts
@@ -1,0 +1,93 @@
+import { Artist, ArtistHistory, Chart } from '@asheville-music-chart/core';
+
+import type { ArtistEventDTO, ChartDTO } from '../dtos';
+import { toChartDTO } from '../mappers';
+import type {
+  ArchiveRepository,
+  ArtistImageService,
+  ChartReadRepository,
+  ChartWriteRepository,
+  EventRepository,
+  UpcomingEventsQuery,
+} from '../ports';
+
+export interface UpdateChartDataRequest {
+  readonly enrichArtistImages?: boolean;
+  readonly includeEvents?: boolean;
+  readonly eventQuery?: UpcomingEventsQuery;
+}
+
+export interface UpdateChartDataResponse {
+  readonly chart: ChartDTO;
+  readonly artistCount: number;
+  readonly archived: boolean;
+  readonly updatedImageUrls: Readonly<Record<string, string>>;
+  readonly eventsByArtist: Readonly<Record<string, readonly ArtistEventDTO[]>>;
+}
+
+export class UpdateChartDataUseCase {
+  constructor(
+    private readonly source: ChartReadRepository,
+    private readonly destination: ChartWriteRepository,
+    private readonly archive: ArchiveRepository,
+    private readonly events?: EventRepository,
+    private readonly images?: ArtistImageService,
+  ) {}
+
+  async execute(request: UpdateChartDataRequest = {}): Promise<UpdateChartDataResponse> {
+    const chart = await this.source.loadLatest();
+    const updatedHistories: ArtistHistory[] = [];
+    const updatedImageUrls = new Map<string, string>();
+    const eventsByArtist = new Map<string, ArtistEventDTO[]>();
+
+    const shouldEnrichImages = request.enrichArtistImages ?? true;
+    const shouldIncludeEvents = (request.includeEvents ?? true) && Boolean(this.events);
+
+    for (const history of chart.entries) {
+      let artist = history.artist;
+
+      if (shouldEnrichImages && this.images && !artist.imageUrl) {
+        const resolvedUrl = await this.images.findImageFor(artist);
+        if (resolvedUrl) {
+          updatedImageUrls.set(artist.id, resolvedUrl);
+          artist = new Artist({
+            id: artist.id,
+            name: artist.name,
+            imageUrl: resolvedUrl,
+            highLevelGenre: artist.highLevelGenre,
+            specificGenre: artist.specificGenre,
+            spotifyUrl: artist.spotifyUrl,
+          });
+        }
+      }
+
+      if (shouldIncludeEvents && this.events) {
+        const artistEvents = await this.events.listUpcomingEvents(artist.id, request.eventQuery);
+        if (artistEvents.length > 0) {
+          eventsByArtist.set(artist.id, [...artistEvents]);
+        }
+      }
+
+      if (artist !== history.artist) {
+        updatedHistories.push(new ArtistHistory(artist, history.weeks));
+      } else {
+        updatedHistories.push(history);
+      }
+    }
+
+    const finalChart = updatedImageUrls.size > 0
+      ? new Chart({ generatedAt: chart.generatedAt, entries: updatedHistories })
+      : chart;
+
+    await this.destination.save(finalChart);
+    await this.archive.saveSnapshot(finalChart);
+
+    return {
+      chart: toChartDTO(finalChart),
+      artistCount: finalChart.size,
+      archived: true,
+      updatedImageUrls: Object.fromEntries(updatedImageUrls.entries()),
+      eventsByArtist: Object.fromEntries(eventsByArtist.entries()),
+    } satisfies UpdateChartDataResponse;
+  }
+}

--- a/packages/application/tests/filter-artists.usecase.test.js
+++ b/packages/application/tests/filter-artists.usecase.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { FilterArtistsUseCase } from '../dist/index.js';
+import { createChart, createArtistHistory } from '../../core/tests/helpers.js';
+
+class StubChartRepository {
+  constructor(chart) {
+    this.chart = chart;
+  }
+
+  async loadLatest() {
+    return this.chart;
+  }
+}
+
+test('filters chart entries and reports match counts for the genre filter scenario', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-indie', name: 'Indigo Ridge', totals: [900, 1300], highLevelGenre: 'Indie' }),
+    createArtistHistory({ id: 'artist-rock', name: 'Beacon Bloom', totals: [1200, 1600], highLevelGenre: 'Rock' }),
+    createArtistHistory({ id: 'artist-pop', name: 'City Lights', totals: [1400, 1900], highLevelGenre: 'Pop', specificGenre: 'Indie Pop' }),
+  ];
+  const chart = createChart(histories);
+  const charts = new StubChartRepository(chart);
+  const useCase = new FilterArtistsUseCase(charts);
+
+  const response = await useCase.execute({ criteria: { genres: ['indie', 'indie pop'], minimumCurrentListens: 1500 } });
+
+  assert.equal(response.totalAvailable, 3);
+  assert.equal(response.totalMatched, 1);
+  assert.equal(response.entries.length, 1);
+  assert.equal(response.entries[0].artist.id, 'artist-pop');
+  assert.equal(response.entries[0].artist.highLevelGenre, 'Pop');
+});
+
+test('returns the full chart when no filter criteria are provided', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-indie', name: 'Indigo Ridge', totals: [900, 1300], highLevelGenre: 'Indie' }),
+    createArtistHistory({ id: 'artist-rock', name: 'Beacon Bloom', totals: [1200, 1600], highLevelGenre: 'Rock' }),
+  ];
+  const chart = createChart(histories);
+  const charts = new StubChartRepository(chart);
+  const useCase = new FilterArtistsUseCase(charts);
+
+  const response = await useCase.execute();
+
+  assert.equal(response.totalAvailable, 2);
+  assert.equal(response.totalMatched, 2);
+  assert.equal(response.entries.length, 2);
+});

--- a/packages/application/tests/get-current-chart.test.js
+++ b/packages/application/tests/get-current-chart.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GetCurrentChartUseCase } from '../dist/index.js';
+import { createChart, createArtistHistory } from '../../core/tests/helpers.js';
+
+class StubChartRepository {
+  constructor(chart) {
+    this.chart = chart;
+    this.loadCalls = 0;
+  }
+
+  async loadLatest() {
+    this.loadCalls += 1;
+    return this.chart;
+  }
+}
+
+test('returns the latest chart projection with artist counts for the landing page', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-a', name: 'Atlas Echo', totals: [1000, 1400] }),
+    createArtistHistory({ id: 'artist-b', name: 'Beacon Bloom', totals: [900, 1200] }),
+  ];
+  const chart = createChart(histories, '2024-07-08T12:00:00.000Z');
+  const charts = new StubChartRepository(chart);
+  const useCase = new GetCurrentChartUseCase(charts);
+
+  const response = await useCase.execute();
+
+  assert.equal(charts.loadCalls, 1);
+  assert.equal(response.artistCount, 2);
+  assert.equal(response.chart.generatedAt, '2024-07-08T12:00:00.000Z');
+  assert.equal(response.chart.entries.length, 2);
+  assert.equal(response.chart.entries[0].artist.id, 'artist-a');
+  assert.equal(response.chart.entries[1].artist.id, 'artist-b');
+});

--- a/packages/application/tests/list-growth-leaders.usecase.test.js
+++ b/packages/application/tests/list-growth-leaders.usecase.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ListGrowthLeadersUseCase } from '../dist/index.js';
+import { createChart, createArtistHistory } from '../../core/tests/helpers.js';
+
+class StubChartRepository {
+  constructor(chart) {
+    this.chart = chart;
+  }
+
+  async loadLatest() {
+    return this.chart;
+  }
+}
+
+test('returns the strongest week-over-week growth leaders for the Hottest tab', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-surge', name: 'Fireline', totals: [800, 1600] }),
+    createArtistHistory({ id: 'artist-steady', name: 'Glowstate', totals: [1200, 1200] }),
+    createArtistHistory({ id: 'artist-rise', name: 'Harmonic Horizon', totals: [600, 900] }),
+  ];
+  const chart = createChart(histories);
+  const charts = new StubChartRepository(chart);
+  const useCase = new ListGrowthLeadersUseCase(charts);
+
+  const response = await useCase.execute({ limit: 2 });
+
+  assert.equal(response.leaders.length, 2);
+  assert.equal(response.leaders[0].history.artist.id, 'artist-surge');
+  assert.equal(response.leaders[0].growth.absoluteChange, 800);
+  assert.equal(response.leaders[0].growth.percentageChange, 100);
+  assert.equal(response.leaders[1].history.artist.id, 'artist-rise');
+  assert.equal(response.leaders[1].growth.absoluteChange, 300);
+  assert.equal(response.leaders[1].rank, 2);
+});

--- a/packages/application/tests/update-chart-data.usecase.test.js
+++ b/packages/application/tests/update-chart-data.usecase.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { UpdateChartDataUseCase } from '../dist/index.js';
+import { createChart, createArtistHistory } from '../../core/tests/helpers.js';
+
+class InMemoryChartRepository {
+  constructor(chart) {
+    this.chart = chart;
+    this.savedCharts = [];
+  }
+
+  async loadLatest() {
+    return this.chart;
+  }
+
+  async save(chart) {
+    this.savedCharts.push(chart);
+  }
+}
+
+class InMemoryArchiveRepository {
+  constructor() {
+    this.saved = [];
+  }
+
+  async listSnapshots() {
+    return [];
+  }
+
+  async loadSnapshot() {
+    return null;
+  }
+
+  async saveSnapshot(chart) {
+    this.saved.push(chart);
+  }
+}
+
+class StubEventRepository {
+  constructor(responses = {}) {
+    this.responses = responses;
+    this.calls = [];
+  }
+
+  async listUpcomingEvents(artistId, query) {
+    this.calls.push({ artistId, query });
+    return this.responses[artistId] ?? [];
+  }
+}
+
+class StubImageService {
+  constructor(responses = {}) {
+    this.responses = responses;
+    this.calls = [];
+  }
+
+  async findImageFor(artist) {
+    this.calls.push(artist.id);
+    return this.responses[artist.id] ?? null;
+  }
+}
+
+test('saves enriched chart data, archives the snapshot, and returns DTO projections', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-a', name: 'Atlas Echo', totals: [1000, 1400] }),
+    createArtistHistory({ id: 'artist-b', name: 'Beacon Bloom', totals: [1200, 1500], imageUrl: 'https://images.test/beacon.jpg' }),
+  ];
+  const chart = createChart(histories, '2024-07-08T12:00:00.000Z');
+
+  const charts = new InMemoryChartRepository(chart);
+  const archive = new InMemoryArchiveRepository();
+  const events = new StubEventRepository({
+    'artist-a': [
+      {
+        artistId: 'artist-a',
+        name: 'Live at The Grey Eagle',
+        startDate: '2024-07-20T20:00:00.000Z',
+        venue: 'The Grey Eagle',
+        city: 'Asheville',
+      },
+    ],
+  });
+  const images = new StubImageService({ 'artist-a': 'https://images.test/atlas.jpg' });
+
+  const useCase = new UpdateChartDataUseCase(charts, charts, archive, events, images);
+  const response = await useCase.execute({ eventQuery: { limit: 5 } });
+
+  assert.equal(response.artistCount, 2);
+  assert.equal(response.archived, true);
+  assert.deepEqual(response.updatedImageUrls, { 'artist-a': 'https://images.test/atlas.jpg' });
+  assert.deepEqual(Object.keys(response.eventsByArtist), ['artist-a']);
+  assert.equal(response.eventsByArtist['artist-a'][0].venue, 'The Grey Eagle');
+  assert.equal(response.chart.entries[0].artist.imageUrl, 'https://images.test/atlas.jpg');
+  assert.equal(response.chart.entries[1].artist.imageUrl, 'https://images.test/beacon.jpg');
+
+  assert.equal(charts.savedCharts.length, 1);
+  assert.equal(archive.saved.length, 1);
+  assert.equal(images.calls.length, 1);
+  assert.equal(images.calls[0], 'artist-a');
+  assert.equal(events.calls.length, 2);
+  assert.equal(events.calls[0].artistId, 'artist-a');
+  assert.equal(events.calls[0].query.limit, 5);
+  assert.equal(events.calls[1].artistId, 'artist-b');
+  assert.equal(events.calls[1].query.limit, 5);
+
+  const savedChart = charts.savedCharts[0];
+  assert.equal(savedChart.entries[0].artist.imageUrl, 'https://images.test/atlas.jpg');
+  assert.equal(savedChart.entries[1].artist.imageUrl, 'https://images.test/beacon.jpg');
+});
+
+test('allows opt-out of enrichment steps when requested', async () => {
+  const histories = [
+    createArtistHistory({ id: 'artist-a', name: 'Atlas Echo', totals: [1000, 1400] }),
+  ];
+  const chart = createChart(histories, '2024-07-08T12:00:00.000Z');
+
+  const charts = new InMemoryChartRepository(chart);
+  const archive = new InMemoryArchiveRepository();
+  const events = new StubEventRepository({ 'artist-a': [{ artistId: 'artist-a', name: 'Pop-up Show', startDate: '2024-07-25T20:00:00.000Z' }] });
+  const images = new StubImageService({ 'artist-a': 'https://images.test/atlas.jpg' });
+
+  const useCase = new UpdateChartDataUseCase(charts, charts, archive, events, images);
+  const response = await useCase.execute({ enrichArtistImages: false, includeEvents: false });
+
+  assert.equal(images.calls.length, 0);
+  assert.equal(events.calls.length, 0);
+  assert.deepEqual(response.updatedImageUrls, {});
+  assert.deepEqual(response.eventsByArtist, {});
+  assert.equal(charts.savedCharts.length, 1);
+  assert.strictEqual(charts.savedCharts[0], chart);
+});

--- a/packages/application/tsconfig.json
+++ b/packages/application/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,17 @@
+# @asheville-music-chart/core
+
+The core package defines the **pure domain model** for the Asheville Music Chart. It is
+framework-agnostic so that the web UI, automation tooling, and future services can share the
+same behaviors.
+
+## Contents
+
+- **Value objects** like `ListenCount` and `DateRange` encapsulate invariants around numeric plays
+  and reporting windows.
+- **Entities** for `Artist`, `WeeklyStat`, `ArtistHistory`, and `Chart` describe the data contracts
+  exchanged between layers and validate their inputs up front.
+- **Domain services** implement reusable policies for ranking artists, calculating growth, and
+  applying filter criteria without relying on presentation or infrastructure concerns.
+
+Because this package has no runtime dependencies, the domain can be exercised in any environment
+(including tests) without provisioning the DOM, filesystem, or network.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@asheville-music-chart/core",
+  "version": "0.0.0",
+  "description": "Domain entities and value objects for the Asheville Music Chart",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "npm run build && node --loader ../../test-support/esm-loader.mjs --test ./tests/*.test.js"
+  }
+}

--- a/packages/core/src/entities/artist-history.ts
+++ b/packages/core/src/entities/artist-history.ts
@@ -1,0 +1,59 @@
+import { Artist } from './artist';
+import { WeeklyStat } from './weekly-stat';
+
+function ensureChronological(stats: WeeklyStat[]): WeeklyStat[] {
+  const ordered = [...stats].sort((a, b) => a.period.start.localeCompare(b.period.start));
+
+  for (let index = 1; index < ordered.length; index += 1) {
+    const previous = ordered[index - 1];
+    const current = ordered[index];
+
+    if (previous.period.end > current.period.start) {
+      throw new Error('Weekly stats must be provided in chronological order without overlap.');
+    }
+  }
+
+  return ordered;
+}
+
+export class ArtistHistory {
+  readonly artist: Artist;
+  private readonly weeklyStats: WeeklyStat[];
+
+  constructor(artist: Artist, stats: Iterable<WeeklyStat>) {
+    const statList = Array.from(stats);
+
+    if (statList.length === 0) {
+      throw new Error('Artist history requires at least one weekly stat.');
+    }
+
+    this.artist = artist;
+    this.weeklyStats = ensureChronological(statList);
+  }
+
+  get weeks(): readonly WeeklyStat[] {
+    return this.weeklyStats;
+  }
+
+  get currentWeek(): WeeklyStat {
+    return this.weeklyStats[this.weeklyStats.length - 1];
+  }
+
+  get previousWeek(): WeeklyStat | undefined {
+    if (this.weeklyStats.length < 2) {
+      return undefined;
+    }
+
+    return this.weeklyStats[this.weeklyStats.length - 2];
+  }
+
+  growthSincePreviousWeek(): number | null {
+    const previous = this.previousWeek;
+
+    if (!previous) {
+      return null;
+    }
+
+    return this.currentWeek.growthSince(previous);
+  }
+}

--- a/packages/core/src/entities/artist.ts
+++ b/packages/core/src/entities/artist.ts
@@ -1,0 +1,74 @@
+export interface ArtistProps {
+  id: string;
+  name: string;
+  imageUrl?: string;
+  highLevelGenre?: string | null;
+  specificGenre?: string | null;
+  spotifyUrl?: string | null;
+}
+
+function assertNonEmpty(value: string, fieldName: string): void {
+  if (!value.trim()) {
+    throw new Error(`${fieldName} cannot be empty.`);
+  }
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class Artist {
+  readonly id: string;
+  readonly name: string;
+  readonly imageUrl?: string;
+  readonly highLevelGenre?: string;
+  readonly specificGenre?: string;
+  readonly spotifyUrl?: string;
+
+  constructor(props: ArtistProps) {
+    assertNonEmpty(props.id, 'Artist id');
+    assertNonEmpty(props.name, 'Artist name');
+
+    this.id = props.id;
+    this.name = props.name;
+
+    if (props.imageUrl) {
+      if (!isValidUrl(props.imageUrl)) {
+        throw new Error('Artist image URL must be a valid URL.');
+      }
+      this.imageUrl = props.imageUrl;
+    }
+
+    if (props.spotifyUrl) {
+      if (!isValidUrl(props.spotifyUrl)) {
+        throw new Error('Spotify URL must be a valid URL.');
+      }
+      this.spotifyUrl = props.spotifyUrl;
+    }
+
+    if (props.highLevelGenre) {
+      this.highLevelGenre = props.highLevelGenre;
+    }
+
+    if (props.specificGenre) {
+      this.specificGenre = props.specificGenre;
+    }
+  }
+
+  matchesGenre(genre: string): boolean {
+    const target = genre.trim().toLowerCase();
+    const highLevelMatch = this.highLevelGenre
+      ? this.highLevelGenre.toLowerCase() === target
+      : false;
+    const specificMatch = this.specificGenre
+      ? this.specificGenre.toLowerCase() === target
+      : false;
+
+    return highLevelMatch || specificMatch;
+  }
+}

--- a/packages/core/src/entities/chart.ts
+++ b/packages/core/src/entities/chart.ts
@@ -1,0 +1,56 @@
+import { ArtistHistory } from './artist-history';
+
+export interface ChartProps {
+  generatedAt: Date | string;
+  entries: Iterable<ArtistHistory>;
+}
+
+function toDate(value: Date | string): Date {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new TypeError('Chart timestamp must be a valid date.');
+    }
+    return value;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new TypeError('Chart timestamp must be a valid ISO date string.');
+  }
+  return parsed;
+}
+
+export class Chart {
+  readonly generatedAt: Date;
+  private readonly entryList: ArtistHistory[];
+  private readonly entryIndex: Map<string, ArtistHistory>;
+
+  constructor({ generatedAt, entries }: ChartProps) {
+    this.generatedAt = toDate(generatedAt);
+    this.entryList = Array.from(entries);
+
+    const index = new Map<string, ArtistHistory>();
+
+    for (const history of this.entryList) {
+      const artistId = history.artist.id;
+      if (index.has(artistId)) {
+        throw new Error(`Duplicate artist detected in chart: ${artistId}`);
+      }
+      index.set(artistId, history);
+    }
+
+    this.entryIndex = index;
+  }
+
+  get entries(): readonly ArtistHistory[] {
+    return this.entryList;
+  }
+
+  findByArtistId(id: string): ArtistHistory | undefined {
+    return this.entryIndex.get(id);
+  }
+
+  get size(): number {
+    return this.entryList.length;
+  }
+}

--- a/packages/core/src/entities/weekly-stat.ts
+++ b/packages/core/src/entities/weekly-stat.ts
@@ -1,0 +1,31 @@
+import { DateRange } from '../value-objects/date-range';
+import { ListenCount } from '../value-objects/listen-count';
+
+export interface WeeklyStatProps {
+  weekStartDate: string;
+  weekEndDate: string;
+  totalListens: number;
+  listensDifference?: number | null;
+}
+
+export class WeeklyStat {
+  readonly period: DateRange;
+  readonly totalListens: ListenCount;
+  readonly listensDifference?: number;
+
+  constructor(props: WeeklyStatProps) {
+    this.period = DateRange.fromISO(props.weekStartDate, props.weekEndDate);
+    this.totalListens = ListenCount.from(props.totalListens);
+
+    if (props.listensDifference != null) {
+      if (!Number.isFinite(props.listensDifference)) {
+        throw new TypeError('Listens difference must be a finite number when provided.');
+      }
+      this.listensDifference = Math.trunc(props.listensDifference);
+    }
+  }
+
+  growthSince(previous: WeeklyStat): number {
+    return this.totalListens.subtract(previous.totalListens);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,16 @@
+export { Artist, type ArtistProps } from './entities/artist';
+export { ArtistHistory } from './entities/artist-history';
+export { Chart, type ChartProps } from './entities/chart';
+export { WeeklyStat, type WeeklyStatProps } from './entities/weekly-stat';
+export { ListenCount } from './value-objects/listen-count';
+export { DateRange } from './value-objects/date-range';
+export {
+  applyRanking,
+  currentListensRule,
+  weekOverWeekGrowthRule,
+  type RankedArtist,
+  type RankingRule,
+  type RankingOptions,
+} from './services/ranking';
+export { currentGrowth, calculateGrowthBetween, type GrowthSnapshot } from './services/growth';
+export { filterArtists, type FilterCriteria } from './services/filtering';

--- a/packages/core/src/services/filtering.ts
+++ b/packages/core/src/services/filtering.ts
@@ -1,0 +1,66 @@
+import { ArtistHistory } from '../entities/artist-history';
+
+export interface FilterCriteria {
+  readonly genres?: readonly string[];
+  readonly searchTerm?: string;
+  readonly minimumCurrentListens?: number;
+}
+
+function matchesGenres(history: ArtistHistory, genres?: readonly string[]): boolean {
+  if (!genres || genres.length === 0) {
+    return true;
+  }
+
+  const normalized = genres.map((genre) => genre.trim().toLowerCase()).filter(Boolean);
+
+  if (normalized.length === 0) {
+    return true;
+  }
+
+  return normalized.some((genre) => history.artist.matchesGenre(genre));
+}
+
+function matchesSearch(history: ArtistHistory, term?: string): boolean {
+  if (!term) {
+    return true;
+  }
+
+  const normalized = term.trim().toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  return history.artist.name.toLowerCase().includes(normalized);
+}
+
+function matchesMinimumListens(history: ArtistHistory, minimum?: number): boolean {
+  if (minimum == null) {
+    return true;
+  }
+
+  if (!Number.isFinite(minimum)) {
+    throw new TypeError('Minimum listens filter must be a finite number.');
+  }
+
+  return history.currentWeek.totalListens.value >= minimum;
+}
+
+export function filterArtists(
+  entries: Iterable<ArtistHistory>,
+  criteria: FilterCriteria = {},
+): ArtistHistory[] {
+  const filtered: ArtistHistory[] = [];
+
+  for (const history of entries) {
+    if (
+      matchesGenres(history, criteria.genres) &&
+      matchesSearch(history, criteria.searchTerm) &&
+      matchesMinimumListens(history, criteria.minimumCurrentListens)
+    ) {
+      filtered.push(history);
+    }
+  }
+
+  return filtered;
+}

--- a/packages/core/src/services/growth.ts
+++ b/packages/core/src/services/growth.ts
@@ -1,0 +1,36 @@
+import { ArtistHistory } from '../entities/artist-history';
+import { WeeklyStat } from '../entities/weekly-stat';
+
+export interface GrowthSnapshot {
+  readonly current: WeeklyStat;
+  readonly previous?: WeeklyStat;
+  readonly absoluteChange: number | null;
+  readonly percentageChange: number | null;
+}
+
+export function calculateGrowthBetween(current: WeeklyStat, previous?: WeeklyStat): GrowthSnapshot {
+  if (!previous) {
+    return {
+      current,
+      previous: undefined,
+      absoluteChange: null,
+      percentageChange: null,
+    } satisfies GrowthSnapshot;
+  }
+
+  const absoluteChange = current.growthSince(previous);
+  const percentageChange = previous.totalListens.value === 0
+    ? null
+    : (absoluteChange / previous.totalListens.value) * 100;
+
+  return {
+    current,
+    previous,
+    absoluteChange,
+    percentageChange,
+  } satisfies GrowthSnapshot;
+}
+
+export function currentGrowth(history: ArtistHistory): GrowthSnapshot {
+  return calculateGrowthBetween(history.currentWeek, history.previousWeek);
+}

--- a/packages/core/src/services/ranking.ts
+++ b/packages/core/src/services/ranking.ts
@@ -1,0 +1,80 @@
+import { ArtistHistory } from '../entities/artist-history';
+import { Chart } from '../entities/chart';
+
+export interface RankingRule {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  score(history: ArtistHistory): number;
+}
+
+export interface RankedArtist {
+  readonly rank: number;
+  readonly score: number;
+  readonly history: ArtistHistory;
+}
+
+export interface RankingOptions {
+  readonly tieBreaker?: (a: ArtistHistory, b: ArtistHistory) => number;
+}
+
+const defaultTieBreaker = (a: ArtistHistory, b: ArtistHistory): number =>
+  a.artist.name.localeCompare(b.artist.name);
+
+export function applyRanking(
+  chart: Chart,
+  rule: RankingRule,
+  options: RankingOptions = {},
+): RankedArtist[] {
+  const tieBreaker = options.tieBreaker ?? defaultTieBreaker;
+
+  const decorated = chart.entries.map((history) => ({
+    history,
+    score: rule.score(history),
+  }));
+
+  decorated.sort((a, b) => {
+    const scoreDelta = b.score - a.score;
+
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+
+    return tieBreaker(a.history, b.history);
+  });
+
+  let currentRank = 0;
+  let lastScore: number | undefined;
+
+  return decorated.map(({ history, score }) => {
+    if (lastScore === undefined || score !== lastScore) {
+      currentRank += 1;
+      lastScore = score;
+    }
+
+    return {
+      rank: currentRank,
+      score,
+      history,
+    } satisfies RankedArtist;
+  });
+}
+
+export const currentListensRule: RankingRule = {
+  id: 'current-listens',
+  label: 'Current week total listens',
+  description: 'Orders artists by the total listens recorded for the most recent week.',
+  score(history) {
+    return history.currentWeek.totalListens.value;
+  },
+};
+
+export const weekOverWeekGrowthRule: RankingRule = {
+  id: 'week-over-week-growth',
+  label: 'Week over week growth',
+  description: 'Orders artists by the change in listens compared to the previous week.',
+  score(history) {
+    const growth = history.growthSincePreviousWeek();
+    return growth ?? Number.NEGATIVE_INFINITY;
+  },
+};

--- a/packages/core/src/utils/is-iso-date-string.ts
+++ b/packages/core/src/utils/is-iso-date-string.ts
@@ -1,0 +1,5 @@
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isISODateString(value: string): boolean {
+  return typeof value === 'string' && ISO_DATE_REGEX.test(value);
+}

--- a/packages/core/src/value-objects/date-range.ts
+++ b/packages/core/src/value-objects/date-range.ts
@@ -1,0 +1,35 @@
+import { isISODateString } from '../utils/is-iso-date-string';
+
+export class DateRange {
+  readonly start: string;
+  readonly end: string;
+
+  private constructor(start: string, end: string) {
+    this.start = start;
+    this.end = end;
+  }
+
+  static fromISO(start: string, end: string): DateRange {
+    if (!isISODateString(start)) {
+      throw new TypeError(`Invalid ISO date string for range start: ${start}`);
+    }
+
+    if (!isISODateString(end)) {
+      throw new TypeError(`Invalid ISO date string for range end: ${end}`);
+    }
+
+    if (end < start) {
+      throw new RangeError('Date range end must be on or after the start date.');
+    }
+
+    return new DateRange(start, end);
+  }
+
+  contains(date: string): boolean {
+    if (!isISODateString(date)) {
+      throw new TypeError(`Invalid ISO date string: ${date}`);
+    }
+
+    return date >= this.start && date <= this.end;
+  }
+}

--- a/packages/core/src/value-objects/listen-count.ts
+++ b/packages/core/src/value-objects/listen-count.ts
@@ -1,0 +1,43 @@
+export class ListenCount {
+  private readonly valueInternal: number;
+
+  private constructor(value: number) {
+    this.valueInternal = value;
+  }
+
+  static from(totalListens: number): ListenCount {
+    if (!Number.isFinite(totalListens)) {
+      throw new TypeError('Listen count must be a finite number.');
+    }
+
+    if (!Number.isInteger(totalListens)) {
+      throw new TypeError('Listen count must be an integer number of plays.');
+    }
+
+    if (totalListens < 0) {
+      throw new RangeError('Listen count cannot be negative.');
+    }
+
+    return new ListenCount(totalListens);
+  }
+
+  get value(): number {
+    return this.valueInternal;
+  }
+
+  add(other: ListenCount): ListenCount {
+    return new ListenCount(this.valueInternal + other.valueInternal);
+  }
+
+  subtract(other: ListenCount): number {
+    return this.valueInternal - other.valueInternal;
+  }
+
+  compare(other: ListenCount): number {
+    return this.valueInternal - other.valueInternal;
+  }
+
+  equals(other: ListenCount): boolean {
+    return this.valueInternal === other.valueInternal;
+  }
+}

--- a/packages/core/tests/filtering.test.js
+++ b/packages/core/tests/filtering.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { filterArtists } from '../dist/index.js';
+import { createArtistHistory } from './helpers.js';
+
+test('filters artists by high-level and specific genre matches for the filter menu scenario', () => {
+  const indie = createArtistHistory({
+    id: 'artist-indie',
+    name: 'Indigo Ridge',
+    totals: [900, 1300],
+    highLevelGenre: 'Indie',
+  });
+  const rock = createArtistHistory({
+    id: 'artist-rock',
+    name: 'Beacon Bloom',
+    totals: [1200, 1600],
+    highLevelGenre: 'Rock',
+  });
+  const indiePop = createArtistHistory({
+    id: 'artist-pop',
+    name: 'City Lights',
+    totals: [1400, 1900],
+    highLevelGenre: 'Pop',
+    specificGenre: 'Indie Pop',
+  });
+
+  const result = filterArtists([indie, rock, indiePop], { genres: ['indie', 'indie pop'] });
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((history) => history.artist.id), ['artist-indie', 'artist-pop']);
+});
+
+test('filters artists by case-insensitive name search', () => {
+  const indie = createArtistHistory({
+    id: 'artist-indie',
+    name: 'Indigo Ridge',
+    totals: [900, 1300],
+    highLevelGenre: 'Indie',
+  });
+  const rock = createArtistHistory({
+    id: 'artist-rock',
+    name: 'Beacon Bloom',
+    totals: [1200, 1600],
+    highLevelGenre: 'Rock',
+  });
+
+  const result = filterArtists([indie, rock], { searchTerm: 'BLOOM' });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].artist.id, 'artist-rock');
+});
+
+test('enforces a minimum listens threshold when requested', () => {
+  const indie = createArtistHistory({
+    id: 'artist-indie',
+    name: 'Indigo Ridge',
+    totals: [900, 1300],
+    highLevelGenre: 'Indie',
+  });
+  const rock = createArtistHistory({
+    id: 'artist-rock',
+    name: 'Beacon Bloom',
+    totals: [1200, 1600],
+    highLevelGenre: 'Rock',
+  });
+  const indiePop = createArtistHistory({
+    id: 'artist-pop',
+    name: 'City Lights',
+    totals: [1400, 1900],
+    highLevelGenre: 'Pop',
+    specificGenre: 'Indie Pop',
+  });
+
+  const result = filterArtists([indie, rock, indiePop], { minimumCurrentListens: 1600 });
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((history) => history.artist.id), ['artist-rock', 'artist-pop']);
+});

--- a/packages/core/tests/growth.test.js
+++ b/packages/core/tests/growth.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { calculateGrowthBetween, currentGrowth } from '../dist/index.js';
+import { createWeeklyStatForIndex, createArtistHistory } from './helpers.js';
+
+test('derives absolute and percentage change between weekly stats', () => {
+  const previous = createWeeklyStatForIndex(0, 1000);
+  const current = createWeeklyStatForIndex(1, 1500, 500);
+
+  const snapshot = calculateGrowthBetween(current, previous);
+
+  assert.equal(snapshot.absoluteChange, 500);
+  assert.equal(snapshot.percentageChange, 50);
+  assert.equal(snapshot.previous.totalListens.value, 1000);
+  assert.equal(snapshot.current.totalListens.value, 1500);
+});
+
+test('omits percentage change when the previous week had no listens', () => {
+  const previous = createWeeklyStatForIndex(0, 0);
+  const current = createWeeklyStatForIndex(1, 200, 200);
+
+  const snapshot = calculateGrowthBetween(current, previous);
+
+  assert.equal(snapshot.absoluteChange, 200);
+  assert.equal(snapshot.percentageChange, null);
+});
+
+test('returns null growth values for artists without a prior week', () => {
+  const history = createArtistHistory({
+    id: 'artist-new',
+    name: 'New Arrival',
+    totals: [700],
+  });
+
+  const snapshot = currentGrowth(history);
+
+  assert.equal(snapshot.previous, undefined);
+  assert.equal(snapshot.absoluteChange, null);
+  assert.equal(snapshot.percentageChange, null);
+});

--- a/packages/core/tests/helpers.js
+++ b/packages/core/tests/helpers.js
@@ -1,0 +1,62 @@
+import {
+  Artist,
+  ArtistHistory,
+  Chart,
+  WeeklyStat,
+} from '../dist/index.js';
+
+const BASE_DATE = new Date('2024-06-03T00:00:00.000Z');
+
+function isoDateFromBase(offsetDays) {
+  const date = new Date(BASE_DATE);
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+  return date.toISOString().slice(0, 10);
+}
+
+export function createWeeklyStatForIndex(index, totalListens, listensDifference) {
+  const props = {
+    weekStartDate: isoDateFromBase(index * 7),
+    weekEndDate: isoDateFromBase(index * 7 + 6),
+    totalListens,
+  };
+
+  if (listensDifference !== undefined) {
+    props.listensDifference = listensDifference;
+  }
+
+  return new WeeklyStat(props);
+}
+
+export function createArtistHistory({
+  id,
+  name,
+  totals,
+  highLevelGenre,
+  specificGenre,
+  imageUrl,
+  spotifyUrl,
+}) {
+  const artist = new Artist({
+    id,
+    name,
+    highLevelGenre,
+    specificGenre,
+    imageUrl,
+    spotifyUrl: spotifyUrl ?? `https://example.com/${id}`,
+  });
+
+  const weeks = totals.map((total, index, arr) => {
+    const previous = index > 0 ? arr[index - 1] : undefined;
+    const difference = previous !== undefined ? total - previous : undefined;
+    return createWeeklyStatForIndex(index, total, difference);
+  });
+
+  return new ArtistHistory(artist, weeks);
+}
+
+export function createChart(histories, generatedAt = '2024-07-01T00:00:00.000Z') {
+  return new Chart({
+    generatedAt,
+    entries: histories,
+  });
+}

--- a/packages/core/tests/ranking.test.js
+++ b/packages/core/tests/ranking.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyRanking,
+  currentListensRule,
+  weekOverWeekGrowthRule,
+} from '../dist/index.js';
+import { createArtistHistory, createChart } from './helpers.js';
+
+test('orders artists by current week listens for the Top tab scenario', () => {
+  const historyA = createArtistHistory({
+    id: 'artist-a',
+    name: 'Artemis Aria',
+    totals: [1200, 1500],
+  });
+  const historyB = createArtistHistory({
+    id: 'artist-b',
+    name: 'Beacon Bloom',
+    totals: [1500, 2100],
+  });
+  const historyC = createArtistHistory({
+    id: 'artist-c',
+    name: 'Crimson Choir',
+    totals: [1800, 1800],
+  });
+
+  const chart = createChart([historyA, historyB, historyC]);
+
+  const ranked = applyRanking(chart, currentListensRule);
+
+  assert.equal(ranked[0].history.artist.id, 'artist-b');
+  assert.equal(ranked[0].rank, 1);
+  assert.equal(ranked[1].history.artist.id, 'artist-c');
+  assert.equal(ranked[1].rank, 2);
+  assert.equal(ranked[2].history.artist.id, 'artist-a');
+  assert.equal(ranked[2].rank, 3);
+});
+
+test('uses alphabetical tie-breakers when current listens are equal', () => {
+  const historyA = createArtistHistory({
+    id: 'artist-a',
+    name: 'Atlas Echo',
+    totals: [1200, 1700],
+  });
+  const historyB = createArtistHistory({
+    id: 'artist-b',
+    name: 'Basilisk',
+    totals: [1200, 1700],
+  });
+
+  const chart = createChart([historyB, historyA]);
+  const ranked = applyRanking(chart, currentListensRule);
+
+  assert.equal(ranked[0].history.artist.name, 'Atlas Echo');
+  assert.equal(ranked[0].rank, 1);
+  assert.equal(ranked[1].history.artist.name, 'Basilisk');
+  assert.equal(ranked[1].rank, 1);
+});
+
+test('prioritizes artists with positive week-over-week growth for the Hottest tab', () => {
+  const surging = createArtistHistory({
+    id: 'artist-hot',
+    name: 'Fireline',
+    totals: [800, 1600],
+  });
+  const steady = createArtistHistory({
+    id: 'artist-steady',
+    name: 'Glowstate',
+    totals: [1500, 1500],
+  });
+  const newcomer = createArtistHistory({
+    id: 'artist-new',
+    name: 'Harmonic Horizon',
+    totals: [900],
+  });
+
+  const chart = createChart([steady, newcomer, surging]);
+  const ranked = applyRanking(chart, weekOverWeekGrowthRule);
+
+  assert.equal(ranked[0].history.artist.id, 'artist-hot');
+  assert.equal(ranked[0].score, 800);
+  assert.equal(ranked[1].history.artist.id, 'artist-steady');
+  assert.equal(ranked[1].score, 0);
+  assert.equal(ranked[2].history.artist.id, 'artist-new');
+  assert.equal(ranked[2].score, Number.NEGATIVE_INFINITY);
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/infrastructure/README.md
+++ b/packages/infrastructure/README.md
@@ -1,0 +1,4 @@
+# @asheville-music-chart/infrastructure
+
+Concrete implementations of persistence, HTTP, and external service adapters will land here.
+They should depend on the application layer interfaces rather than the other way around.

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@asheville-music-chart/infrastructure",
+  "version": "0.0.0",
+  "description": "Infrastructure adapters for data access and integrations",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "node -e \"console.log('No infrastructure tests defined yet')\""
+  }
+}

--- a/packages/infrastructure/src/index.ts
+++ b/packages/infrastructure/src/index.ts
@@ -1,0 +1,2 @@
+// Infrastructure adapters will be developed in later steps of the refactor.
+export const infrastructurePlaceholder = true;

--- a/packages/infrastructure/tsconfig.json
+++ b/packages/infrastructure/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/test-support/esm-loader.mjs
+++ b/test-support/esm-loader.mjs
@@ -1,0 +1,62 @@
+import { access, stat } from 'node:fs/promises';
+import { dirname, extname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const loaderDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolvePath(loaderDir, '..');
+
+const aliasMap = {
+  '@asheville-music-chart/core': resolvePath(repoRoot, 'packages/core/dist/index.js'),
+  '@asheville-music-chart/application': resolvePath(repoRoot, 'packages/application/dist/index.js'),
+  '@asheville-music-chart/infrastructure': resolvePath(repoRoot, 'packages/infrastructure/dist/index.js'),
+};
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveAsFileOrDirectory(candidatePath, context, defaultResolve) {
+  if (await pathExists(`${candidatePath}.js`)) {
+    return defaultResolve(pathToFileURL(`${candidatePath}.js`).href, context, defaultResolve);
+  }
+
+  try {
+    const stats = await stat(candidatePath);
+    if (stats.isDirectory()) {
+      const indexPath = join(candidatePath, 'index.js');
+      if (await pathExists(indexPath)) {
+        return defaultResolve(pathToFileURL(indexPath).href, context, defaultResolve);
+      }
+    }
+  } catch {
+    // ignore missing directory
+  }
+
+  return null;
+}
+
+export async function resolve(specifier, context, defaultResolve) {
+  const aliasTarget = aliasMap[specifier];
+  if (aliasTarget && (await pathExists(aliasTarget))) {
+    return defaultResolve(pathToFileURL(aliasTarget).href, context, defaultResolve);
+  }
+
+  if ((specifier.startsWith('./') || specifier.startsWith('../')) && context.parentURL) {
+    const parentPath = fileURLToPath(context.parentURL);
+    const candidatePath = resolvePath(dirname(parentPath), specifier);
+
+    if (!extname(candidatePath)) {
+      const resolved = await resolveAsFileOrDirectory(candidatePath, context, defaultResolve);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  return defaultResolve(specifier, context, defaultResolve);
+}

--- a/tools/data-pipeline/README.md
+++ b/tools/data-pipeline/README.md
@@ -1,0 +1,5 @@
+# @asheville-music-chart/data-pipeline
+
+Use this workspace to coordinate data ingestion flows such as Soundcharts updates or future
+scrapers. The `legacy:update` script continues to execute the existing Node script until the
+refactor replaces it with a TypeScript implementation.

--- a/tools/data-pipeline/package.json
+++ b/tools/data-pipeline/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@asheville-music-chart/data-pipeline",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Data ingestion and CLI tooling for the Asheville Music Chart",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "node -e \"console.log('No data-pipeline tests defined yet')\"",
+    "legacy:update": "node ../../scripts/updateData.js"
+  }
+}

--- a/tools/data-pipeline/src/index.ts
+++ b/tools/data-pipeline/src/index.ts
@@ -1,0 +1,2 @@
+// Data pipeline orchestration will be migrated here in future steps.
+export const dataPipelinePlaceholder = true;

--- a/tools/data-pipeline/tsconfig.json
+++ b/tools/data-pipeline/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "moduleDetection": "force",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "declaration": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@asheville-music-chart/core": ["packages/core/src/index.ts"],
+      "@asheville-music-chart/application": ["packages/application/src/index.ts"],
+      "@asheville-music-chart/infrastructure": ["packages/infrastructure/src/index.ts"]
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: [
+      'packages/**/*.test.ts',
+      'apps/**/*.test.ts',
+      'tools/**/*.test.ts'
+    ]
+  }
+});


### PR DESCRIPTION
## Summary
- add node:test suites for the core ranking, growth, and filtering behaviors with shared fixtures
- exercise application use cases against user scenarios for filtering, growth leaders, current chart, and update pipeline orchestration
- introduce a reusable ESM loader for node --test and update workspace scripts/gitignore to support the new harness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2347d1f08333bc644545de787e2b