### PR TITLE
Handle non-fast-forward pushes in update workflow

### DIFF
--- a/.github/workflows/friday-chart-update.yml
+++ b/.github/workflows/friday-chart-update.yml
@@ -75,5 +75,13 @@ jobs:
     
     - name: Commit and push if changed
       run: |
+        git pull --rebase origin main
         git add data.js
-        git diff --quiet && git diff --staged --quiet || (git commit -m "Update chart data [skip ci]" && git push) 
+
+        if git diff --quiet && git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+
+        git commit -m "Update chart data [skip ci]"
+        git push origin HEAD:main


### PR DESCRIPTION
## Summary
- add a rebase pull before committing automated chart updates
- avoid empty commits when no data changes are present
- push explicitly to the main branch after updates

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920cb1660cc8333b7ffad093a298bab)