### PR TITLE
Remove Electro Lust entry from artists list

### DIFF
--- a/scripts/artists.json
+++ b/scripts/artists.json
@@ -200,18 +200,6 @@
       "detailed_bio": "Hustle Souls is an Asheville-based band merging vintage soul, brass-band funk, and singer-songwriter Americana. Powered by roaring Hammond B3 organ, jubilant horn lines, and three-part vocal harmonies, the group has been praised for its vibrant, generation-bridging sound. Named one of Music Connection Magazine's Hot 100 Unsigned Artists, Hustle Souls have appeared at major festivals and shared stages with artists like Dumpstaphunk and Kofi Burbridge. Their 2024 vinyl debut and NAMM Show performances further cemented their status as one of the Southeast's most exciting modern soul-funk bands."
   },
   {
-      "uuid": "759c027c-4319-11e9-afea-801844edfa71",
-      "name": "Electro Lust",
-      "imageUrl": "https://assets.soundcharts.com/artist/9/1/3/759c027c-4319-11e9-afea-801844edfa71.jpg",
-      "high_level_genre": "Urban/Electronic",
-      "specific_genre": "Electro-Funk with Latin & Afrobeat Heat",
-      "spotifyUrl": "https://open.spotify.com/artist/4I7KgQAeHXS9LwGyaD0dpB",
-      "appleMusicUrl": "https://music.apple.com/us/artist/1733611052",
-      "youtubeUrl": "https://www.youtube.com/channel/UC7_eciJpAqWO7tkdZ9u34eQ",
-      "concise_bio": "An Asheville supergroup fusing electronic production with live brass, funk, Latin, Cuban, and Afrobeat influences into club-ready dance anthems.",
-      "detailed_bio": "Electro Lust is a high-voltage electro-funk supergroup made up of Grammy-winning members of Yo Mama's Big Fat Booty Band, The Fritz, and Empire Strikes Brass. Their sound blends punchy electronic beats with live trombone, trumpet, sax, keys, guitar, and drums—creating a kaleidoscopic mix of funk, Latin, Cuban, and Afrobeat textures. Their shows feel like a midnight Miami club colliding with a Brazilian street party and a Havana jam session, stitched together with hip-hop swagger and festival-grade energy."
-  },
-  {
       "uuid": "4a406de9-ed4f-4557-96aa-66c558d2fb1a",
       "name": "Snake Oil Medicine Show",
       "imageUrl": "https://assets.soundcharts.com/artist/f/4/d/4a406de9-ed4f-4557-96aa-66c558d2fb1a.jpg",


### PR DESCRIPTION
## Summary
- remove the Electro Lust artist entry from the source artists list so it is excluded from generated data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e814b5d883338ee361d80c31c0b9)