### PR TITLE
Enable GA production tracking and status checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'G-2CMRZC02S5', {
-      'send_page_view': false
+      'send_page_view': true
     });
   </script>
 

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -3,30 +3,26 @@
  * Handles all custom event tracking with environment detection
  */
 
-const GA4_CONFIG = {
-  production: 'G-2CMRZC02S5',  // Asheville Music Chart - Production
-  development: null  // Set to dev Measurement ID or null to disable locally
-};
-
-function getEnvironment() {
-  const hostname = window.location.hostname;
-  if (hostname === 'localhost' || hostname === '127.0.0.1' ||
-      hostname.startsWith('192.168.') || hostname.endsWith('.local')) {
-    return 'development';
-  }
-  if (hostname === 'www.ashevillemusicchart.com' ||
-      hostname === 'ashevillemusicchart.com') {
-    return 'production';
-  }
-  return 'development';
-}
+const MEASUREMENT_ID = 'G-2CMRZC02S5';
 
 function getMeasurementId() {
-  return GA4_CONFIG[getEnvironment()];
+  return MEASUREMENT_ID;
 }
 
 function isAnalyticsEnabled() {
-  return typeof window.gtag === 'function' && getMeasurementId() !== null;
+  return typeof window.gtag === 'function' && Boolean(getMeasurementId());
+}
+
+export function getAnalyticsStatus() {
+  const measurementId = getMeasurementId();
+  const hasGtag = typeof window.gtag === 'function';
+
+  return {
+    measurementId,
+    hasGtag,
+    dataLayerReady: Array.isArray(window.dataLayer),
+    enabled: hasGtag && Boolean(measurementId)
+  };
 }
 
 function sendEvent(eventName, eventParams = {}) {
@@ -43,12 +39,15 @@ function sendEvent(eventName, eventParams = {}) {
 }
 
 export function initAnalytics() {
-  const env = getEnvironment();
-  console.log(`[Analytics] Initializing in ${env} mode`);
+  console.log('[Analytics] Initializing');
 
   if (!getMeasurementId()) {
-    console.log('[Analytics] Disabled in development');
+    console.warn('[Analytics] Measurement ID missing, analytics disabled');
     return;
+  }
+
+  if (!window.dataLayer) {
+    console.warn('[Analytics] dataLayer not initialized—gtag may not be ready yet');
   }
 
   sendPageView(window.location.pathname + window.location.hash);


### PR DESCRIPTION
## Summary
- simplify analytics configuration to always use the production GA4 Measurement ID and log readiness warnings
- add a helper to inspect runtime analytics status
- enable automatic GA page view collection in the global tag config

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938cdf1fadc8333b067a771d1ab7f98)