### PR TITLE
Align analytics event names with click convention and add service tracking

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -91,29 +91,27 @@ function getDeviceType() {
   return 'desktop';
 }
 
-// Priority Event 4: Tab View
-export function trackTabView(tabName, source = 'unknown') {
-  sendEvent('tab_view', {
+// Priority Event 4: Tab navigation
+export function trackTabNavigation(tabName, source = 'unknown') {
+  sendEvent('click_tab', {
     tab_name: tabName,
     navigation_source: source,
     device_type: getDeviceType()
   });
 }
 
-// Priority 1: Artist Click
-export function trackArtistClick(artistName, platform, rank, tab) {
-  sendEvent('artist_click', {
-    artist_name: artistName,
-    platform: platform,
-    artist_rank: rank,
+// Priority 2: Share
+export function trackShareVisibility(action, tab) {
+  const eventName = action === 'show' ? 'click_show_share' : 'click_hide_share';
+
+  sendEvent(eventName, {
     tab_name: tab,
     device_type: getDeviceType()
   });
 }
 
-// Priority 2: Share
-export function trackShare(method, tab) {
-  sendEvent('share', {
+export function trackShareCompletion(method, tab) {
+  sendEvent('click_shared', {
     method: method,
     content_type: 'chart',
     tab_name: tab,
@@ -123,7 +121,11 @@ export function trackShare(method, tab) {
 
 // Priority 5: Bio Toggle
 export function trackBioToggle(artistName, action, rank) {
-  sendEvent('bio_toggle', {
+  const eventName = action === 'expand'
+    ? 'click_show_artist_detail'
+    : 'click_hide_artist_detail';
+
+  sendEvent(eventName, {
     artist_name: artistName,
     action: action,
     artist_rank: rank,
@@ -133,7 +135,9 @@ export function trackBioToggle(artistName, action, rank) {
 
 // Priority 7: Info Toggle
 export function trackInfoToggle(action, tab) {
-  sendEvent('info_toggle', {
+  const eventName = action === 'show' ? 'click_show_info' : 'click_hide_info';
+
+  sendEvent(eventName, {
     action: action,
     tab_name: tab,
     device_type: getDeviceType()
@@ -142,9 +146,20 @@ export function trackInfoToggle(action, tab) {
 
 // Priority 6: External Navigation
 export function trackExternalNav(destination, url) {
-  sendEvent('external_navigation', {
+  sendEvent('click_external_navigation', {
     destination: destination,
     url: url,
+    device_type: getDeviceType()
+  });
+}
+
+// Music service links
+export function trackMusicServiceLink(artistName, platform, rank, tab) {
+  sendEvent('click_music_service', {
+    artist_name: artistName,
+    platform: platform,
+    artist_rank: rank,
+    tab_name: tab,
     device_type: getDeviceType()
   });
 }

--- a/js/artistCells.js
+++ b/js/artistCells.js
@@ -1,5 +1,5 @@
 import { getAnimationStartTime, getAnimatedValue, createAnimationController } from './streamAnimation.js';
-import { trackArtistClick, trackBioToggle } from './analytics.js';
+import { trackMusicServiceLink, trackBioToggle } from './analytics.js';
 
 export function renderArtistCells(container, artistsData, timestamp) {
   // Clean up any existing cells' animation controllers
@@ -229,7 +229,7 @@ class ArtistCell {
                         link.classList.contains('youtube-link-bio') ? 'youtube' :
                         link.classList.contains('tidal-link-bio') ? 'tidal' : 'unknown';
 
-        trackArtistClick(
+        trackMusicServiceLink(
           this.artistData.artist.name,
           platform,
           this.index + 1,

--- a/js/mainMenu.js
+++ b/js/mainMenu.js
@@ -61,7 +61,7 @@ function renderMainMenu(container) {
                            link.classList.contains('feedback-button') ? 'give_feedback' : 'unknown';
 
         if (typeof window.gtag === 'function') {
-          window.gtag('event', 'external_navigation', {
+          window.gtag('event', 'click_external_navigation', {
             destination: destination,
             url: link.href,
             device_type: window.innerWidth <= 768 ? 'mobile' :

--- a/js/router.js
+++ b/js/router.js
@@ -4,7 +4,7 @@
  * Provides URL routing for Top, Hottest, and Shows tabs
  */
 
-import { trackTabView } from './analytics.js';
+import { trackTabNavigation } from './analytics.js';
 
 const VALID_TABS = ['top', 'hottest', 'shows'];
 const DEFAULT_TAB = 'top';
@@ -74,7 +74,7 @@ function initRouter(onTabChange) {
   // Handle hash changes (back/forward buttons, manual hash edits)
   const handleHashChange = () => {
     const tabName = getTabFromHash();
-    trackTabView(tabName, 'hash_change');
+    trackTabNavigation(tabName, 'hash_change');
     onTabChange(tabName, false); // false = don't update hash (prevent loop)
   };
 


### PR DESCRIPTION
## Summary
- rename tab view, artist selection, and external navigation analytics events to use the click_* naming convention
- update main menu navigation tracking to emit the new click_external_navigation event name
- replace tab and artist tracking helpers with tab navigation and click_music_service events for Spotify, Apple, YouTube, and Tidal buttons

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d74657fc8333991fd1a60de9e05a)